### PR TITLE
Bugfix: Uncaught exception occurs when there are directories under stylesheetsPath

### DIFF
--- a/lib/package-watcher.coffee
+++ b/lib/package-watcher.coffee
@@ -28,7 +28,7 @@ class PackageWatcher extends Watcher
     stylesheetPaths = @pack.getStylesheetPaths()
     if fs.existsSync(stylesheetsPath)
       stylesheetPaths = stylesheetPaths.concat(path.join(stylesheetsPath, p) \
-      for p in fs.listTreeSync(stylesheetsPath) when p.substr(-5) == '.less')
+      for p in fs.listTreeSync(stylesheetsPath) when p.substr(-5) == '.less') and fs.isFileSync(p)
 
     watchPath(stylesheet) for stylesheet in _.uniq(stylesheetPaths)
 


### PR DESCRIPTION
Just watch the '.less' files under `stylesheetsPath` and its subdirectries
