### PR TITLE
Cleanup

### DIFF
--- a/lib/base-theme-watcher.js
+++ b/lib/base-theme-watcher.js
@@ -11,7 +11,7 @@ class BaseThemeWatcher extends Watcher {
   }
 
   watch () {
-    const filePaths = fs.readdirSync(this.stylesheetsPath).filter(filePath => path.extname(filePath).indexOf('less') > -1)
+    const filePaths = fs.readdirSync(this.stylesheetsPath).filter(filePath => path.extname(filePath).includes('less'))
 
     for (const filePath of filePaths) {
       this.watchFile(path.join(this.stylesheetsPath, filePath))

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,15 +5,15 @@ module.exports = {
     if (!atom.inDevMode() || atom.inSpecMode()) return
 
     let uiWatcher = null
-    const activatedDisposable = atom.packages.onDidActivateInitialPackages(() => {
+    this.activatedDisposable = atom.packages.onDidActivateInitialPackages(() => {
       uiWatcher = new UIWatcher({themeManager: atom.themes})
-      activatedDisposable.dispose()
+      this.commandDisposable = atom.commands.add('atom-workspace', 'dev-live-reload:reload-all', () => uiWatcher.reloadAll())
+      this.activatedDisposable.dispose()
     })
-
-    this.commandDisposable = atom.commands.add('atom-workspace', 'dev-live-reload:reload-all', () => uiWatcher && uiWatcher.reloadAll())
   },
 
   deactivate () {
+    if (this.activatedDisposable) this.activatedDisposable.dispose()
     if (this.commandDisposable) this.commandDisposable.dispose()
   }
 }

--- a/lib/package-watcher.js
+++ b/lib/package-watcher.js
@@ -20,7 +20,7 @@ class PackageWatcher extends Watcher {
   watch () {
     const watchedPaths = []
     const watchPath = stylesheet => {
-      if (!_.contains(watchedPaths, stylesheet)) this.watchFile(stylesheet)
+      if (!watchedPaths.includes(stylesheet)) this.watchFile(stylesheet)
       watchedPaths.push(stylesheet)
     }
 
@@ -41,7 +41,7 @@ class PackageWatcher extends Watcher {
   }
 
   loadStylesheet (pathName) {
-    if (pathName.indexOf('variables') > -1) this.emitGlobalsChanged()
+    if (pathName.includes('variables')) this.emitGlobalsChanged()
     this.loadAllStylesheets()
   }
 

--- a/lib/package-watcher.js
+++ b/lib/package-watcher.js
@@ -1,4 +1,3 @@
-const _ = require('underscore-plus')
 const fs = require('fs-plus')
 
 const Watcher = require('./watcher')

--- a/lib/package-watcher.js
+++ b/lib/package-watcher.js
@@ -28,12 +28,12 @@ class PackageWatcher extends Watcher {
 
     if (fs.isDirectorySync(stylesheetsPath)) this.watchDirectory(stylesheetsPath)
 
-    const stylesheetPaths = this.pack.getStylesheetPaths()
-    const onFile = stylesheetPath => stylesheetPaths.push(stylesheetPath)
+    const stylesheetPaths = new Set(this.pack.getStylesheetPaths())
+    const onFile = stylesheetPath => stylesheetPaths.add(stylesheetPath)
     const onFolder = () => true
     fs.traverseTreeSync(stylesheetsPath, onFile, onFolder)
 
-    for (let stylesheet of _.uniq(stylesheetPaths)) {
+    for (let stylesheet of stylesheetPaths) {
       watchPath(stylesheet)
     }
 

--- a/lib/ui-watcher.js
+++ b/lib/ui-watcher.js
@@ -12,8 +12,8 @@ class UIWatcher {
   }
 
   watchPackages () {
-    this.watchedThemes = {}
-    this.watchedPackages = {}
+    this.watchedThemes = new Map()
+    this.watchedPackages = new Map()
     for (const theme of atom.themes.getActiveThemes()) { this.watchTheme(theme) }
     for (const pack of atom.packages.getLoadedPackages()) { this.watchPackage(pack) }
     this.watchForPackageChanges()
@@ -23,20 +23,20 @@ class UIWatcher {
     atom.themes.onDidChangeActiveThemes(() => {
       // we need to destroy all watchers as all theme packages are destroyed when a
       // theme changes.
-      for (const name in this.watchedThemes) { this.watchedThemes[name].destroy() }
+      for (const theme of this.watchedThemes.values()) { theme.destroy() }
 
-      this.watchedThemes = {}
+      this.watchedThemes.clear()
       // Rewatch everything!
       for (const theme of atom.themes.getActiveThemes()) { this.watchTheme(theme) }
     })
   }
 
   watchTheme (theme) {
-    if (PackageWatcher.supportsPackage(theme, 'theme')) this.watchedThemes[theme.name] = this.createWatcher(new PackageWatcher(theme))
+    if (PackageWatcher.supportsPackage(theme, 'theme')) this.watchedThemes.set(theme.name, this.createWatcher(new PackageWatcher(theme)))
   }
 
   watchPackage (pack) {
-    if (PackageWatcher.supportsPackage(pack, 'atom')) this.watchedPackages[pack.name] = this.createWatcher(new PackageWatcher(pack))
+    if (PackageWatcher.supportsPackage(pack, 'atom')) this.watchedPackages.set(pack.name, this.createWatcher(new PackageWatcher(pack)))
   }
 
   createWatcher (watcher) {
@@ -62,7 +62,7 @@ class UIWatcher {
 
   destroy () {
     this.baseTheme.destroy()
-    for (const name in this.watchedPackages) { this.watchedPackages[name].destroy() }
-    for (const name in this.watchedThemes) { this.watchedThemes[name].destroy() }
+    for (const pack of this.watchedPackages.values()) { pack.destroy() }
+    for (const theme of this.watchedThemes.values()) { theme.destroy() }
   }
 }

--- a/lib/ui-watcher.js
+++ b/lib/ui-watcher.js
@@ -1,4 +1,3 @@
-const _ = require('underscore-plus')
 const BaseThemeWatcher = require('./base-theme-watcher')
 const PackageWatcher = require('./package-watcher')
 
@@ -44,7 +43,7 @@ class UIWatcher {
       console.log('Global changed, reloading all styles')
       this.reloadAll()
     })
-    watcher.onDidDestroy(() => { this.watchers = _.without(this.watchers, watcher) })
+    watcher.onDidDestroy(() => this.watchers.splice(this.watchers.indexOf(watcher), 1))
     this.watchers.push(watcher)
     return watcher
   }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "repository": "https://github.com/atom/dev-live-reload",
   "license": "MIT",
   "dependencies": {
-    "fs-plus": "^3.0.0",
-    "underscore-plus": "1.x"
+    "fs-plus": "^3.0.0"
   },
   "engines": {
     "atom": "*"

--- a/spec/ui-watcher-spec.js
+++ b/spec/ui-watcher-spec.js
@@ -84,7 +84,7 @@ describe('UIWatcher', () => {
         spyOn(theme, 'reloadStylesheets')
       }
 
-      for (const entity of uiWatcher.watchedThemes['theme-with-multiple-imported-files'].entities) {
+      for (const entity of uiWatcher.watchedThemes.get('theme-with-multiple-imported-files').entities) {
         if (entity.getPath().indexOf('variables') > -1) varEntity = entity
       }
       varEntity.emitter.emit('did-change')
@@ -110,7 +110,7 @@ describe('UIWatcher', () => {
       spyOn(pack, 'reloadStylesheets')
       spyOn(atom.themes, 'reloadBaseStylesheets')
 
-      const watcher = uiWatcher.watchedThemes['theme-with-index-less']
+      const watcher = uiWatcher.watchedThemes.get('theme-with-index-less')
 
       expect(watcher.entities.length).toBe(1)
 
@@ -136,7 +136,7 @@ describe('UIWatcher', () => {
       spyOn(pack, 'reloadStylesheets')
       spyOn(atom.themes, 'reloadBaseStylesheets')
 
-      const watcher = uiWatcher.watchedThemes['theme-with-multiple-imported-files']
+      const watcher = uiWatcher.watchedThemes.get('theme-with-multiple-imported-files')
 
       expect(watcher.entities.length).toBe(6)
 
@@ -159,14 +159,14 @@ describe('UIWatcher', () => {
       jasmine.useRealClock()
 
       atom.config.set('core.themes', ['theme-with-syntax-variables', 'theme-with-package-file'])
-      await conditionPromise(() => uiWatcher.watchedThemes['theme-with-package-file'])
+      await conditionPromise(() => uiWatcher.watchedThemes.get('theme-with-package-file'))
 
       pack = atom.themes.getActiveThemes()[0]
       spyOn(pack, 'reloadStylesheets')
 
       expect(pack.name).toBe('theme-with-package-file')
 
-      const watcher = uiWatcher.watchedThemes['theme-with-package-file']
+      const watcher = uiWatcher.watchedThemes.get('theme-with-package-file')
       watcher.entities[2].emitter.emit('did-change')
       expect(pack.reloadStylesheets).toHaveBeenCalled()
     })

--- a/spec/ui-watcher-spec.js
+++ b/spec/ui-watcher-spec.js
@@ -1,4 +1,3 @@
-const _ = require('underscore-plus')
 const path = require('path')
 
 const UIWatcher = require('../lib/ui-watcher')
@@ -34,11 +33,13 @@ describe('UIWatcher', () => {
     await atom.packages.activatePackage(packagePath)
     uiWatcher = new UIWatcher()
 
-    expect(_.last(uiWatcher.watchers).entities.length).toBe(4)
-    expect(_.last(uiWatcher.watchers).entities[0].getPath()).toBe(path.join(packagePath, 'styles'))
-    expect(_.last(uiWatcher.watchers).entities[1].getPath()).toBe(path.join(packagePath, 'styles', '3.css'))
-    expect(_.last(uiWatcher.watchers).entities[2].getPath()).toBe(path.join(packagePath, 'styles', 'sub', '1.css'))
-    expect(_.last(uiWatcher.watchers).entities[3].getPath()).toBe(path.join(packagePath, 'styles', 'sub', '2.less'))
+    const lastWatcher = uiWatcher.watchers[uiWatcher.watchers.length - 1]
+
+    expect(lastWatcher.entities.length).toBe(4)
+    expect(lastWatcher.entities[0].getPath()).toBe(path.join(packagePath, 'styles'))
+    expect(lastWatcher.entities[1].getPath()).toBe(path.join(packagePath, 'styles', '3.css'))
+    expect(lastWatcher.entities[2].getPath()).toBe(path.join(packagePath, 'styles', 'sub', '1.css'))
+    expect(lastWatcher.entities[3].getPath()).toBe(path.join(packagePath, 'styles', 'sub', '2.less'))
   })
 
   describe('when a package stylesheet file changes', async () => {
@@ -51,7 +52,7 @@ describe('UIWatcher', () => {
       const pack = atom.packages.getActivePackages()[0]
       spyOn(pack, 'reloadStylesheets')
 
-      _.last(uiWatcher.watchers).entities[1].emitter.emit('did-change')
+      uiWatcher.watchers[uiWatcher.watchers.length - 1].entities[1].emitter.emit('did-change')
 
       expect(pack.reloadStylesheets).toHaveBeenCalled()
     })
@@ -144,7 +145,7 @@ describe('UIWatcher', () => {
       expect(pack.reloadStylesheets).toHaveBeenCalled()
       expect(atom.themes.reloadBaseStylesheets).not.toHaveBeenCalled()
 
-      _.last(watcher.entities).emitter.emit('did-change')
+      watcher.entities[watcher.entities.length - 1].emitter.emit('did-change')
       expect(atom.themes.reloadBaseStylesheets).toHaveBeenCalled()
     })
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tried to separate everything into different commits so that it was clear what I did.
* Reorganize activation to make a bit more sense - only add the command after initial packages have activated and make sure the `onDidActivateInitialPackages` subscription is disposed if `dev-live-reload` activates and then is deactivated before all packages are loaded
* When testing if a string fragment exists, use `.includes` rather than `.indexOf`
* Use Sets for built-in uniqueness
* Use Maps to avoid breakage when a package is named `__proto__`
* Removed underscore-plus dependency in favor of native methods

### Alternate Designs

N/A

### Benefits

Easier to understand code.

### Possible Drawbacks

Possibility for regressions.  I have and will continue to stress test this package before publishing a new release.

### Applicable Issues

None.