### PR TITLE
Improve package activation and deactivation lifecycle

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -4,16 +4,22 @@ module.exports = {
   activate (state) {
     if (!atom.inDevMode() || atom.inSpecMode()) return
 
-    let uiWatcher = null
-    this.activatedDisposable = atom.packages.onDidActivateInitialPackages(() => {
-      uiWatcher = new UIWatcher({themeManager: atom.themes})
-      this.commandDisposable = atom.commands.add('atom-workspace', 'dev-live-reload:reload-all', () => uiWatcher.reloadAll())
-      this.activatedDisposable.dispose()
-    })
+    if (atom.packages.hasActivatedInitialPackages()) {
+      this.startWatching()
+    } else {
+      this.activatedDisposable = atom.packages.onDidActivateInitialPackages(() => this.startWatching())
+    }
   },
 
   deactivate () {
     if (this.activatedDisposable) this.activatedDisposable.dispose()
     if (this.commandDisposable) this.commandDisposable.dispose()
+    if (this.uiWatcher) this.uiWatcher.destroy()
+  },
+
+  startWatching () {
+    this.uiWatcher = new UIWatcher({themeManager: atom.themes})
+    this.commandDisposable = atom.commands.add('atom-workspace', 'dev-live-reload:reload-all', () => this.uiWatcher.reloadAll())
+    if (this.activatedDisposable) this.activatedDisposable.dispose()
   }
 }

--- a/spec/dev-live-reload-spec.js
+++ b/spec/dev-live-reload-spec.js
@@ -1,0 +1,124 @@
+const {it, fit, ffit, afterEach, beforeEach} = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
+
+describe('Dev Live Reload', () => {
+  describe('package activation', () => {
+    let [pack, mainModule] = []
+
+    beforeEach(() => {
+      pack = atom.packages.loadPackage('dev-live-reload')
+      pack.requireMainModule()
+      mainModule = pack.mainModule
+      spyOn(mainModule, 'startWatching')
+    })
+
+    describe('when the window is not in dev mode', () => {
+      beforeEach(() => spyOn(atom, 'inDevMode').andReturn(false))
+
+      it('does not watch files', async () => {
+        spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true)
+
+        await atom.packages.activatePackage('dev-live-reload')
+        expect(mainModule.startWatching).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the window is in spec mode', () => {
+      beforeEach(() => spyOn(atom, 'inSpecMode').andReturn(true))
+
+      it('does not watch files', async () => {
+        spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true)
+
+        await atom.packages.activatePackage('dev-live-reload')
+        expect(mainModule.startWatching).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the window is in dev mode', () => {
+      beforeEach(() => {
+        spyOn(atom, 'inDevMode').andReturn(true)
+        spyOn(atom, 'inSpecMode').andReturn(false)
+      })
+
+      it('watches files', async () => {
+        spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true)
+
+        await atom.packages.activatePackage('dev-live-reload')
+        expect(mainModule.startWatching).toHaveBeenCalled()
+      })
+    })
+
+    describe('when the window is in both dev mode and spec mode', () => {
+      beforeEach(() => {
+        spyOn(atom, 'inDevMode').andReturn(true)
+        spyOn(atom, 'inSpecMode').andReturn(true)
+      })
+
+      it('does not watch files', async () => {
+        spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true)
+
+        await atom.packages.activatePackage('dev-live-reload')
+        expect(mainModule.startWatching).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the package is activated before initial packages have been activated', () => {
+      beforeEach(() => {
+        spyOn(atom, 'inDevMode').andReturn(true)
+        spyOn(atom, 'inSpecMode').andReturn(false)
+      })
+
+      it('waits until all initial packages have been activated before watching files', async () => {
+        await atom.packages.activatePackage('dev-live-reload')
+        expect(mainModule.startWatching).not.toHaveBeenCalled()
+
+        atom.packages.emitter.emit('did-activate-initial-packages')
+        expect(mainModule.startWatching).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('package deactivation', () => {
+    beforeEach(() => {
+      spyOn(atom, 'inDevMode').andReturn(true)
+      spyOn(atom, 'inSpecMode').andReturn(false)
+    })
+
+    it('stops watching all files', async () => {
+      spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true)
+      const {mainModule} = await atom.packages.activatePackage('dev-live-reload')
+      expect(mainModule.uiWatcher).not.toBeNull()
+
+      spyOn(mainModule.uiWatcher, 'destroy')
+
+      await atom.packages.deactivatePackage('dev-live-reload')
+      expect(mainModule.uiWatcher.destroy).toHaveBeenCalled()
+    })
+
+    it('unsubscribes from the onDidActivateInitialPackages subscription if it is disabled before all initial packages are activated', async () => {
+      const {mainModule} = await atom.packages.activatePackage('dev-live-reload')
+      expect(mainModule.activatedDisposable.disposed).toBe(false)
+
+      await atom.packages.deactivatePackage('dev-live-reload')
+      expect(mainModule.activatedDisposable.disposed).toBe(true)
+
+      spyOn(mainModule, 'startWatching')
+      atom.packages.emitter.emit('did-activate-initial-packages')
+      expect(mainModule.startWatching).not.toHaveBeenCalled()
+    })
+
+    it('removes its commands', async () => {
+      spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true)
+      await atom.packages.activatePackage('dev-live-reload')
+      expect(atom.commands
+            .findCommands({target: atom.views.getView(atom.workspace)})
+            .filter(command => command.name.startsWith('dev-live-reload'))
+            .length).toBeGreaterThan(0)
+
+      await atom.packages.deactivatePackage('dev-live-reload')
+      expect(atom.commands
+            .findCommands({target: atom.views.getView(atom.workspace)})
+            .filter(command => command.name.startsWith('dev-live-reload'))
+            .length).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
* Start watching if initial packages have already activated
* Stop watching on package deactivation

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR improves the overall package lifecycle and adds a new spec file to specifically test the main module.

* Previously, dev-live-reload assumed that it would always be activated on initial package startup.  However, if it was disabled and then re-enabled during an active Atom session, it wouldn't receive the `onDidActivateInitialPackages` event and therefore never start watching files.  To solve this, a `hasActivatedInitialPackages` check has been added that when true instructs dev-live-reload to immediately start watching files.
* When deactivating the package, only the disposables were disposed of.  This did not include the actual Watchers.  Therefore if the package was activated and then deactivated, all stylesheets would continue to be watched.  To solve this, all UI watchers are now destroyed on deactivation.
* A new spec file, `dev-live-reload-spec.js`, has been added that tests package activation and deactivation.

### Alternate Designs

None.

### Benefits

More robust package lifecycle.

### Possible Drawbacks

None.

### Applicable Issues

None.