### PR TITLE
UI Watcher lifecycle improvements

### DIFF
--- a/lib/package-watcher.js
+++ b/lib/package-watcher.js
@@ -12,7 +12,6 @@ class PackageWatcher extends Watcher {
   constructor (pack) {
     super()
     this.pack = pack
-    this.pack.onDidDeactivate(this.destroy)
     this.watch()
   }
 

--- a/lib/ui-watcher.js
+++ b/lib/ui-watcher.js
@@ -1,9 +1,12 @@
+const {CompositeDisposable} = require('atom')
+
 const BaseThemeWatcher = require('./base-theme-watcher')
 const PackageWatcher = require('./package-watcher')
 
 module.exports =
 class UIWatcher {
   constructor () {
+    this.subscriptions = new CompositeDisposable()
     this.reloadAll = this.reloadAll.bind(this)
     this.watchers = []
     this.baseTheme = this.createWatcher(new BaseThemeWatcher())
@@ -14,20 +17,30 @@ class UIWatcher {
     this.watchedThemes = new Map()
     this.watchedPackages = new Map()
     for (const theme of atom.themes.getActiveThemes()) { this.watchTheme(theme) }
-    for (const pack of atom.packages.getLoadedPackages()) { this.watchPackage(pack) }
+    for (const pack of atom.packages.getActivePackages()) { this.watchPackage(pack) }
     this.watchForPackageChanges()
   }
 
   watchForPackageChanges () {
-    atom.themes.onDidChangeActiveThemes(() => {
-      // we need to destroy all watchers as all theme packages are destroyed when a
-      // theme changes.
+    this.subscriptions.add(atom.themes.onDidChangeActiveThemes(() => {
+      // We need to destroy all theme watchers as all theme packages are destroyed
+      // when a theme changes.
       for (const theme of this.watchedThemes.values()) { theme.destroy() }
 
       this.watchedThemes.clear()
+
       // Rewatch everything!
       for (const theme of atom.themes.getActiveThemes()) { this.watchTheme(theme) }
-    })
+    }))
+
+    this.subscriptions.add(atom.packages.onDidActivatePackage(pack => this.watchPackage(pack)))
+
+    this.subscriptions.add(atom.packages.onDidDeactivatePackage(pack => {
+      // This only handles packages - onDidChangeActiveThemes handles themes
+      const watcher = this.watchedPackages.get(pack.name)
+      if (watcher) watcher.destroy()
+      this.watchedPackages.delete(pack.name)
+    }))
   }
 
   watchTheme (theme) {
@@ -60,6 +73,7 @@ class UIWatcher {
   }
 
   destroy () {
+    this.subscriptions.dispose()
     this.baseTheme.destroy()
     for (const pack of this.watchedPackages.values()) { pack.destroy() }
     for (const theme of this.watchedThemes.values()) { theme.destroy() }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Builds on #28.  That PR made sure that the UI watcher was started and stopped correctly.  This PR ensures that all sub-watchers in UIWatcher start and stop correctly.  Specifically:
* Start watching packages when they are activated
* Stop watching packages when they are deactivated
* Stop watching for package changes when the UIWatcher is destroyed
* Handle watcher destruction in the higher-level UIWatcher instead of each individual watcher

Previously, even if the UIWatcher had been destroyed (i.e. through package deactivation), it would continue to watch themes if the active themes changed.  It also would fail to start watching packages if they were activated after the UIWatcher was instantiated.

### Alternate Designs

None.

### Benefits

Packages should be watched correctly.

### Possible Drawbacks

None.

### Applicable Issues

None.