### PR TITLE
Defer UIWatcher require until needed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,3 @@
-const UIWatcher = require('./ui-watcher')
-
 module.exports = {
   activate (state) {
     if (!atom.inDevMode() || atom.inSpecMode()) return
@@ -18,6 +16,7 @@ module.exports = {
   },
 
   startWatching () {
+    const UIWatcher = require('./ui-watcher')
     this.uiWatcher = new UIWatcher({themeManager: atom.themes})
     this.commandDisposable = atom.commands.add('atom-workspace', 'dev-live-reload:reload-all', () => this.uiWatcher.reloadAll())
     if (this.activatedDisposable) this.activatedDisposable.dispose()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This brings down activation time from ~50ms to ~5ms for me in non-dev windows.  Don't think we can get any faster than that :P.

### Alternate Designs

None.

### Benefits

Faster startup time.

### Possible Drawbacks

None.

### Applicable Issues

None.